### PR TITLE
Update GoogleGenomics dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,11 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 val googleAPIVersion = "1.20.0"
-val googleAPIGenomicsVersion = "v1beta2-rev3-1.19.0"
+val googleAPIGenomicsVersion = "v1beta2-rev34-1.20.0"
 
 val sparkVersion = "1.3.0"
 
-val genomicsUtilsVersion = "v1beta2-0.19"
+val genomicsUtilsVersion = "v1beta2-0.23"
 
 val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty", name = "servlet-api")
 

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/GenomicsConf.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/GenomicsConf.scala
@@ -21,6 +21,7 @@ import org.rogach.scallop.ScallopConf
 import org.apache.spark.SparkConf
 import com.google.cloud.genomics.Client
 import com.google.cloud.genomics.utils.Contig
+import com.google.cloud.genomics.utils.Contig.SexChromosomeFilter
 import com.google.api.services.genomics.Genomics
 
 class GenomicsConf(arguments: Seq[String]) extends ScallopConf(arguments) {
@@ -57,7 +58,7 @@ class GenomicsConf(arguments: Seq[String]) extends ScallopConf(arguments) {
 }
 
 object PcaConf {
-  val ExcludeXY = true
+  val ExcludeXY = SexChromosomeFilter.EXCLUDE_XY
 }
 
 class PcaConf(arguments: Seq[String]) extends GenomicsConf(arguments) {

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsRDD.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsRDD.scala
@@ -25,6 +25,7 @@ import com.google.api.services.genomics.model.{Read => ReadModel}
 import com.google.api.services.genomics.model.SearchReadsRequest
 import com.google.cloud.genomics.Client
 import com.google.cloud.genomics.utils.Paginator
+import com.google.cloud.genomics.utils.Paginator.ShardBoundary
 import com.google.api.services.genomics.model.CigarUnit
 import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth
 
@@ -105,7 +106,7 @@ class ReadsRDD(sc: SparkContext,
   override def compute(part: Partition, ctx: TaskContext):
     Iterator[(ReadKey, Read)] = {
     val client = Client(auth).genomics
-    val reads = Paginator.Reads.create(client)
+    val reads = Paginator.Reads.create(client, ShardBoundary.STRICT)
     val partition = part.asInstanceOf[ReadsPartition]
     val req = new SearchReadsRequest()
       .setReadGroupSetIds(partition.readGroupSetIds)

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/VariantsRDD.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/VariantsRDD.scala
@@ -28,6 +28,7 @@ import com.google.api.services.genomics.model.SearchVariantsRequest
 import com.google.api.services.genomics.model.{Variant => VariantModel}
 import com.google.cloud.genomics.Client
 import com.google.cloud.genomics.utils.Paginator
+import com.google.cloud.genomics.utils.Paginator.ShardBoundary
 import org.apache.spark.Accumulator
 import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth
 import com.google.cloud.genomics.utils.Contig
@@ -186,7 +187,7 @@ class VariantsRDD(sc: SparkContext,
   override def compute(part: Partition, ctx: TaskContext):
     Iterator[(VariantKey, Variant)] = {
     val client = Client(auth)
-    val reads = Paginator.Variants.create(client.genomics)
+    val reads = Paginator.Variants.create(client.genomics, ShardBoundary.STRICT)
     val partition = part.asInstanceOf[VariantsPartition]
     val req = partition.getVariantsRequest
     val iterator = reads.search(req).iterator().map(variant => {


### PR DESCRIPTION
The variants and reads API return records that overlap the start and end of the shard.

By specifying ShardBoundary.STRICT on the client-side Paginator throws away records that overlap the start of the shard since they will be present in the prior shard.
